### PR TITLE
Fix for newer jade versions

### DIFF
--- a/settings.json
+++ b/settings.json
@@ -1,0 +1,3 @@
+{
+"contentExtension": ".txt"
+}

--- a/templates/default/download.jade
+++ b/templates/default/download.jade
@@ -4,9 +4,9 @@
 -   return /nightly/.test(name1) ? 1 : parseInt(name1.match(/(\d*)$/)[1]) < parseInt(name2.match(/(\d*)$/)[1]);
 - });
 for file in files
-  version = file.name.split('-')[1]
+  - version = file.name.split('-')[1]
   if !/^v/.test(version)
-    version = version.charAt(0).toUpperCase() + version.slice(1)
+    - version = version.charAt(0).toUpperCase() + version.slice(1)
   .download
     .image
         a.nohover(href=file.url)

--- a/templates/default/html.jade
+++ b/templates/default/html.jade
@@ -1,4 +1,4 @@
-!!! 5
+doctype html
 html
   !{template('head', root, param)}
   body

--- a/templates/default/page.jade
+++ b/templates/default/page.jade
@@ -1,5 +1,5 @@
 //- Render content template before, to get access to param.titles
-content = template('content')
+- content = template("content")
 article(class=inPath(root.get('tutorials')) ? 'tutorial' : page.type)
   if !param.titles || !param.titles.length || !param.titles[0].isFirst
     h1 !{page.title}

--- a/templates/default/tutorials_aside.jade
+++ b/templates/default/tutorials_aside.jade
@@ -1,4 +1,4 @@
-tutorials = root.get('tutorials')
+- tutorials = root.get('tutorials')
 if tutorials && (tutorials == page || tutorials.isAncestor(page))
   h1 Index
   !{ template('tutorials_index', tutorials) }

--- a/templates/example/html.jade
+++ b/templates/example/html.jade
@@ -1,4 +1,4 @@
-!!! 5
+doctype html
 html
   !{template('head', root, param)}
   body.fullscreen

--- a/templates/example/thumbnail.jade
+++ b/templates/example/thumbnail.jade
@@ -1,11 +1,11 @@
-id = 'thumb-' + page.index
+- id = 'thumb-' + page.index
 .thumbnail
   .resource
     a.hover(href=page.url)
-      thumb = page.files[0]
+      - thumb = page.files[0]
       if thumb
-        monoThumb = thumb.exportThumb({ width: 242, grayscale: true })
-        thumb = thumb.exportThumb({ width: 242 })
+        - monoThumb = thumb.exportThumb({ width: 242, grayscale: true })
+        - thumb = thumb.exportThumb({ width: 242 })
         img.normal(src=monoThumb.url, width=monoThumb.width, height=monoThumb.height)
         img.over.hidden(src=thumb.url, width=thumb.width, height=thumb.height)
   .caption

--- a/templates/examples/content.jade
+++ b/templates/examples/content.jade
@@ -1,4 +1,4 @@
 .thumbnails
-  list = page.children
+  - list = page.children
   for child in page.flip == 'true' ? list.flip() : list
     !{template('thumbnail', child)}

--- a/templates/external/thumbnail.jade
+++ b/templates/external/thumbnail.jade
@@ -1,11 +1,11 @@
-id = 'thumb-' + page.index
+- id = 'thumb-' + page.index
 .thumbnail
   .resource
     a.hover(href=page.link, target="_blank")
-      thumb = page.files[0]
+      - thumb = page.files[0]
       if thumb
-        monoThumb = thumb.exportThumb({ width: 242, grayscale: true})
-        thumb = thumb.exportThumb({ width: 242 })
+        - monoThumb = thumb.exportThumb({ width: 242, grayscale: true})
+        - thumb = thumb.exportThumb({ width: 242 })
         img.normal(src=monoThumb.url, width=monoThumb.width, height=monoThumb.height)
         img.over.hidden(src=thumb.url, width=thumb.width, height=thumb.height)
   .caption

--- a/templates/home/html.jade
+++ b/templates/home/html.jade
@@ -1,4 +1,4 @@
-!!! 5
+doctype html
 html
   !{template('head', root, param)}
   body.fullscreen

--- a/templates/tutorial/aside.jade
+++ b/templates/tutorial/aside.jade
@@ -1,1 +1,1 @@
-!{ template('tutorials_aside') }
+!=template('tutorials_aside')


### PR DESCRIPTION
~~I saw one additional error on the donwload page. Some of the earlier release dates were NaN. Might have been my git setup though, since it managed to extract most of the release dates anyway.~~
(Of course it didn't work, as I didn't have the paperjs repo cloned locally.)
