### PR TITLE
Possible mistake in explanation of code

### DIFF
--- a/content/07-Tutorials/03-Paths/03-Using Color and Style/tutorial.txt
+++ b/content/07-Tutorials/03-Paths/03-Using Color and Style/tutorial.txt
@@ -186,7 +186,7 @@ As I mentioned earlier, all newly created items automatically receive the curren
 
 <api project.currentStyle /> is the <api PathStyle /> object of the project and contains the currently active style properties such as <code>fillColor</code> and <code>strokeColor</code>.
 
-The following example changes the current style of the project, then creates a path which inherits that style. Then it changes only the <code>strokeWidth</code> and creates another path.
+The following example changes the current style of the project, then creates a path which inherits that style. Then it changes the <code>strokeWidth</code> and <code>fillColor</code> and creates another path.
 
 <image "currentStyle.gif" />
 


### PR DESCRIPTION
The explanation above the block of code in the "Working with the Current Style of the Project" section says that the code "changes only the strokeWidth and creates another path" when in reality it changes strokeWidth and fillColor as well. Might be confusing hence corrected it. I have added the <code></code> tags around "fillColor" keeping with the convention.