### PR TITLE
Added missing apostrophe

### DIFF
--- a/content/08-Reference/MouseEvent/class.txt
+++ b/content/08-Reference/MouseEvent/class.txt
@@ -28,7 +28,7 @@
 	
 		<ul class="member-list">
 			<h4>Values:</h4>
-			<li><tt>'mousedown'</tt>, <tt>'mouseup'</tt>, <tt>'mousedrag'</tt>, <tt>'click'</tt>, <tt>'doubleclick'</tt>, <tt>'mousemove'</tt>, <tt>'mouseenter'</tt>, <tt>mouseleave'</tt></li>
+			<li><tt>'mousedown'</tt>, <tt>'mouseup'</tt>, <tt>'mousedrag'</tt>, <tt>'click'</tt>, <tt>'doubleclick'</tt>, <tt>'mousemove'</tt>, <tt>'mouseenter'</tt>, <tt>'mouseleave'</tt></li>
 		</ul>
 	
 	


### PR DESCRIPTION
I copied and pasted the values for some Typescript Typings I'm working on and noticed it was missing.

I'm not a Nazi, I swear!