### PR TITLE
Fix RoundRectangle deprecated documentation

### DIFF
--- a/content/07-Tutorials/03-Paths/02-Creating Predefined Shapes/tutorial.txt
+++ b/content/07-Tutorials/03-Paths/02-Creating Predefined Shapes/tutorial.txt
@@ -30,21 +30,21 @@ path.selected = true;
 
 <title short="Rounded Rectangles">Rectangular Shaped Paths with Rounded Corners</title>
 
-To create rectangular shaped paths with rounded corners, we use the <api Path.RoundedRectangle(rect,size) /> constructor. The <code>rect</code> parameter describes the <api Rectangle /> and the <code>size</code> parameter describes the <api Size /> of the rounded corners.
+To create rectangular shaped paths with rounded corners, we use the <api Path.Rectangle(rectangle)>new Path.Rectangle(rectangle, radius)</api> constructor. The <code>rectangle</code> parameter describes the <api Rectangle /> and the <code>radius</code> parameter describes the <api Size /> of the rounded corners.
 
 For example, the following script creates a rectangular shaped path with 20 pt * 20 pt corners:
 <paperscript height=140 split=true>
 var rectangle = new Rectangle(new Point(50, 50), new Point(150, 100));
-var cornerSize = new Size(20, 20);
-var path = new Path.RoundRectangle(rectangle, cornerSize);
+var radius = new Size(20, 20);
+var path = new Path.Rectangle(rectangle, radius);
 path.fillColor = 'black';
 </paperscript>
 
 <title>Regular Polygon Shaped Paths</title>
 
-To create regular polygon shaped paths, we use the <api Path.RegularPolygon(center,numSides,radius) /> constructor.
+To create regular polygon shaped paths, we use the <api Path.RegularPolygon(center,sides,radius) /> constructor.
 
-The <api Point>center</api> parameter describes the center point of the polygon, the <code>numSides</code> parameter describes the amount of sides the polygon has and the <code>radius</code> parameter describes the radius of the polygon.
+The <api Point>center</api> parameter describes the center point of the polygon, the <code>sides</code> parameter describes the amount of sides the polygon has and the <code>radius</code> parameter describes the radius of the polygon.
 
 For example, lets create a triangle shaped path and a decagon shaped path:
 <paperscript height=140 split=true>


### PR DESCRIPTION
Replaces deprecated rounded rectangle constructor: `new Path.RoundedRectangle(rect,size)` by new one: `new Path.Rectangle(rectangle, radius)`.

Closes https://github.com/paperjs/paper.js/issues/1393