### PR TITLE
Remove `event.pressure` from mouse tool tutorial

### DIFF
--- a/content/07-Tutorials/04-Interaction/01-Creating Mouse Tools/tutorial.txt
+++ b/content/07-Tutorials/04-Interaction/01-Creating Mouse Tools/tutorial.txt
@@ -43,7 +43,7 @@ function onMouseUp(event) {
 
 <title>The Event Object</title>
 
-The mouse handler functions receive an event object which contains information about the mouse event, such as the current position of the mouse (<api ToolEvent#point>event.point</api>), the position where the mouse was pressed (<api ToolEvent#downPoint>event.downPoint</api>), the pressure of the mouse event (<api ToolEvent#pressure>event.pressure</api>) etc.
+The mouse handler functions receive an event object which contains information about the mouse event, such as the current position of the mouse (<api ToolEvent#point>event.point</api>), the position where the mouse was pressed (<api ToolEvent#downPoint>event.downPoint</api>) etc.
 
 <tip>
 The properties of the event object are explained in detail in the <page "/tutorials/interaction/mouse-tool-events/" /> tutorial.


### PR DESCRIPTION
ToolEvent#pressure is not implemented in actual version of Paper.js