### PR TITLE
Close tags in Interoperability tutorial

### DIFF
--- a/content/07-Tutorials/01-Getting Started/03-PaperScript Interoperability/tutorial.txt
+++ b/content/07-Tutorials/01-Getting Started/03-PaperScript Interoperability/tutorial.txt
@@ -1,4 +1,4 @@
-Both PaperScript and JavaScript have access to the Window scope, therefore you can use <code>window.globals<code> from the JavaScript and <code>globals<code> from PaperScript to pass information back and forth.
+Both PaperScript and JavaScript have access to the Window scope, therefore you can use <code>window.globals</code> from the JavaScript and <code>globals</code> from PaperScript to pass information back and forth.
 
 <title>JavaScript <=> PaperScript example</title>
 


### PR DESCRIPTION
The tutorial page for PaperScript Interoperability (http://paperjs.org/tutorials/getting-started/paperscript-interoperability/) is rendering a little weirdly, I think it's because the `<code>` tags on line 1 aren't closed.